### PR TITLE
fix: remove letter line breaks stripped by HTML sanitizer

### DIFF
--- a/src/lib/components/ui/rich-text-editor/rich-text-editor.svelte
+++ b/src/lib/components/ui/rich-text-editor/rich-text-editor.svelte
@@ -23,6 +23,15 @@
 		}
 	});
 
+	function ensureParagraphSeparator() {
+		if (!editorEl) return;
+		try {
+			document.execCommand('defaultParagraphSeparator', false, 'p');
+		} catch {
+			// unsupported in some browsers
+		}
+	}
+
 	function syncValue() {
 		if (editorEl) value = editorEl.innerHTML;
 	}
@@ -176,6 +185,7 @@
 		contenteditable="true"
 		data-placeholder={placeholder}
 		class="min-h-[200px] resize-none px-3 py-2 text-base outline-none empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground focus-visible:ring-0"
+		onfocus={ensureParagraphSeparator}
 		oninput={syncValue}
 		onpaste={syncValue}
 		onkeydown={handleKeydown}

--- a/src/lib/utils/sanitize-html.ts
+++ b/src/lib/utils/sanitize-html.ts
@@ -6,6 +6,11 @@
 
 const ALLOWED_TAGS = new Set(['b', 'i', 'u', 's', 'span', 'br', 'p']);
 
+/** contenteditable often emits <div>; normalize to <p> before sanitizing. */
+function normalizeLetterBlockTags(html: string): string {
+	return html.replace(/<div(\s[^>]*)?>/gi, '<p>').replace(/<\/div>/gi, '</p>');
+}
+
 /** Extract only "color: value" from a style string; drops everything else. */
 function sanitizeStyle(style: string): string {
 	const colorMatch = /color\s*:\s*([^;]+)/i.exec(style);
@@ -35,6 +40,7 @@ function parseOpeningTag(raw: string): { name: string; style?: string } | null {
 
 export function sanitizeLetterHtml(html: string): string {
 	if (typeof html !== 'string') return '';
+	html = normalizeLetterBlockTags(html);
 	let out = '';
 	let i = 0;
 	while (i < html.length) {
@@ -83,5 +89,5 @@ export function stripHtmlToText(html: string): string {
 
 /** True if content looks like HTML we should render with @html. */
 export function isLetterHtml(content: string): boolean {
-	return typeof content === 'string' && /<(?:\/?(?:b|i|u|s|span|br|p)(?:\s|>))/i.test(content);
+	return typeof content === 'string' && /<(?:\/?(?:b|i|u|s|span|br|p|div)(?:\s|>))/i.test(content);
 }

--- a/src/routes/(app)/letters/[id]/+page.svelte
+++ b/src/routes/(app)/letters/[id]/+page.svelte
@@ -232,3 +232,9 @@
 		{/if}
 	{/if}
 </div>
+
+<style>
+	:global(.letter-content p + p) {
+		margin-top: 1em;
+	}
+</style>


### PR DESCRIPTION
## Why
Letter line breaks disappeared because the editor saved `<motion>` blocks but the sanitizer only kept `<p>` / `<br>`.

## What changed
Normalize `<div>` → `<p>` on save, default the editor to `<p>` paragraphs, and add paragraph spacing in letter view.

## Breaking change
No

## Test plan
- [x] Write a letter with multiple paragraphs; confirm breaks show on detail page
- [x] Edit and re-save an older letter if breaks were lost before this fix